### PR TITLE
Proper JSON Encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 
 Heavily based on an excellent writeup from Rayhan Ahmed: [Automating Blind SQL injection over WebSocket](https://rayhan0x01.github.io/ctf/2021/04/02/blind-sqli-over-websocket-automation.html)
 
+## Fork Changes
+- Proper JSON Encoding
+  - before: " was replaced with ', leading to problems with payloads
+  - now: using json.dumps to escape "
+
 ## Example
 ```
 sqlmap-websocket-proxy -u ws://sketcy.lol:1337 -p '{"id": "%param%"}'

--- a/src/sqlmap_websocket_proxy/handler.py
+++ b/src/sqlmap_websocket_proxy/handler.py
@@ -70,7 +70,7 @@ def send_inject(
     params = [x for _, x in parse_qsl(path)]
 
     if json_encode:
-        params = [unquote(x).replace('"',"'") for x in params]
+        params = [json.dumps(unquote(x))[1:-1] for x in params]
 
     for x in params:
         data = data.replace("%param%", x, 1)


### PR DESCRIPTION
Instead of replacing " with ', "s are now being JSON encoded. Thus it is possible to exploit SQL Injections where " is used for the query string